### PR TITLE
Add basic tagging

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -13,6 +13,7 @@ Documentation:
 
 Metrics/BlockLength:
   Exclude:
+    - 'app/models/concerns/**/*'
     - 'spec/controllers/**/*'
     - 'spec/helpers/**/*'
     - 'spec/models/**/*'

--- a/README.md
+++ b/README.md
@@ -1,24 +1,17 @@
-# README
+# Bookmark Manager
 
-This README would normally document whatever steps are necessary to get the
-application up and running.
+Easily save and search your bookmarks.
 
-Things you may want to cover:
+## Installation
 
-* Ruby version
+Clone this repository.
 
-* System dependencies
+	% git clone https://github.com/christopherstyles/bookmark-manager.git
 
-* Configuration
+Setup dependencies and create the databases.
 
-* Database creation
+    % bin/setup
 
-* Database initialization
+Run the server.
 
-* How to run the test suite
-
-* Services (job queues, cache servers, search engines, etc.)
-
-* Deployment instructions
-
-* ...
+    % rails s

--- a/app/controllers/bookmarks_controller.rb
+++ b/app/controllers/bookmarks_controller.rb
@@ -23,6 +23,7 @@ class BookmarksController < ApplicationController
 
   # POST /bookmarks
   # POST /bookmarks.json
+  # rubocop:disable Metrics/MethodLength
   def create
     @bookmark = Bookmark.new(bookmark_params)
 
@@ -41,9 +42,11 @@ class BookmarksController < ApplicationController
       end
     end
   end
+  # rubocop:enable Metrics/MethodLength
 
   # PATCH/PUT /bookmarks/1
   # PATCH/PUT /bookmarks/1.json
+  # rubocop:disable Metrics/MethodLength
   def update
     respond_to do |format|
       if @bookmark.update(bookmark_params)
@@ -60,6 +63,7 @@ class BookmarksController < ApplicationController
       end
     end
   end
+  # rubocop:enable Metrics/MethodLength
 
   # DELETE /bookmarks/1
   # DELETE /bookmarks/1.json
@@ -83,6 +87,6 @@ class BookmarksController < ApplicationController
   end
 
   def bookmark_params
-    params.require(:bookmark).permit(:url)
+    params.require(:bookmark).permit(:tag_list, :url)
   end
 end

--- a/app/models/bookmark.rb
+++ b/app/models/bookmark.rb
@@ -1,3 +1,5 @@
 class Bookmark < ApplicationRecord
+  include Taggable
+
   validates :url, presence: true
 end

--- a/app/models/concerns/taggable.rb
+++ b/app/models/concerns/taggable.rb
@@ -1,0 +1,27 @@
+require 'active_support/concern'
+
+module Taggable
+  extend ActiveSupport::Concern
+
+  included do
+    has_many :taggings, -> { includes(:tag).order(:created_at) },
+             as: :taggable,
+             dependent: :destroy
+
+    has_many :tags, through: :taggings
+
+    after_save :save_tags
+
+    attr_writer :tag_list
+
+    def tag_list
+      @tag_list = tags.map(&:name).join(', ')
+    end
+
+    def save_tags
+      self.tags = @tag_list.to_s.split(',').map do |tag_name|
+        Tag.find_or_create_by!(name: tag_name.strip)
+      end
+    end
+  end
+end

--- a/app/models/tag.rb
+++ b/app/models/tag.rb
@@ -1,0 +1,3 @@
+class Tag < ApplicationRecord
+  has_many :taggings
+end

--- a/app/models/tagging.rb
+++ b/app/models/tagging.rb
@@ -1,0 +1,12 @@
+class Tagging < ApplicationRecord
+  belongs_to :tag, counter_cache: true
+  belongs_to :taggable, polymorphic: true
+
+  after_destroy :remove_unused_tags
+
+  private
+
+  def remove_unused_tags
+    tag.destroy if tag.reload.taggings_count.zero?
+  end
+end

--- a/app/views/bookmarks/_form.html.slim
+++ b/app/views/bookmarks/_form.html.slim
@@ -9,4 +9,6 @@
   .field
     = f.label :url
     = f.text_area :url
+    = f.label :tag_list
+    = f.text_field :tag_list
   .actions = f.submit

--- a/app/views/bookmarks/show.html.slim
+++ b/app/views/bookmarks/show.html.slim
@@ -1,8 +1,12 @@
 p#notice = notice
 
 p
-  strong Url:
+  strong> Url:
   = @bookmark.url
+
+p
+  strong> Tags:
+  = @bookmark.tag_list
 
 = link_to 'Edit', edit_bookmark_path(@bookmark)
 '  |

--- a/db/migrate/20170911071239_create_tags.rb
+++ b/db/migrate/20170911071239_create_tags.rb
@@ -1,0 +1,12 @@
+class CreateTags < ActiveRecord::Migration[5.1]
+  def change
+    create_table :tags, id: :uuid do |t|
+      t.string :name, null: false
+      t.integer :taggings_count, default: 0
+
+      t.timestamps
+    end
+
+    add_index :tags, :name, unique: true
+  end
+end

--- a/db/migrate/20170911071605_create_taggings.rb
+++ b/db/migrate/20170911071605_create_taggings.rb
@@ -1,0 +1,12 @@
+class CreateTaggings < ActiveRecord::Migration[5.1]
+  def change
+    create_table :taggings, id: :uuid do |t|
+      t.references :tag, null: false, index: true, foreign_key: { on_delete: :cascade }, type: :uuid
+
+      t.string :taggable_type, null: false
+      t.uuid :taggable_id, null: false
+
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20170911051511) do
+ActiveRecord::Schema.define(version: 20170911071605) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -22,4 +22,22 @@ ActiveRecord::Schema.define(version: 20170911051511) do
     t.datetime "updated_at", null: false
   end
 
+  create_table "taggings", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
+    t.uuid "tag_id", null: false
+    t.string "taggable_type", null: false
+    t.uuid "taggable_id", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["tag_id"], name: "index_taggings_on_tag_id"
+  end
+
+  create_table "tags", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
+    t.string "name", null: false
+    t.integer "taggings_count", default: 0
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["name"], name: "index_tags_on_name", unique: true
+  end
+
+  add_foreign_key "taggings", "tags", on_delete: :cascade
 end

--- a/spec/factories/taggings.rb
+++ b/spec/factories/taggings.rb
@@ -1,0 +1,6 @@
+FactoryGirl.define do
+  factory :tagging do
+    taggable_type { Faker::Lorem.word }
+    taggable_id { SecureRandom.uuid }
+  end
+end

--- a/spec/factories/tags.rb
+++ b/spec/factories/tags.rb
@@ -1,0 +1,6 @@
+FactoryGirl.define do
+  factory :tag do
+    name { Faker::Lorem.word }
+    type { Faker::Lorem.word }
+  end
+end

--- a/spec/models/bookmark_spec.rb
+++ b/spec/models/bookmark_spec.rb
@@ -4,4 +4,50 @@ RSpec.describe Bookmark, type: :model do
   let(:bookmark) { build_stubbed(:bookmark) }
 
   it { is_expected.to validate_presence_of(:url) }
+
+  # TODO: Extract to a shared example set
+  describe '#tag_list' do
+    let(:bookmark) { create(:bookmark) }
+
+    it 'returns a list of tags' do
+      tag = Tag.create(name: 'potatoes')
+      bookmark.tags << tag
+      bookmark.reload
+      expect(bookmark.tag_list).to eq('potatoes')
+    end
+  end
+
+  describe '#tag_list=' do
+    let(:bookmark) { create(:bookmark) }
+
+    it 'creates a list of tags' do
+      bookmark.tag_list = 'greens, vegetables'
+      bookmark.save
+      expect(bookmark.reload.tags.collect(&:name))
+        .to eq(%w[greens vegetables])
+    end
+  end
+
+  describe 'after_save' do
+    let(:bookmark) { build(:bookmark) }
+
+    it 'creates new tags' do
+      bookmark.tag_list = 'lentils, spicy'
+      expect { bookmark.save }.to change(Tag, :count).by(2)
+    end
+
+    it 'saves a given tag' do
+      bookmark.tag_list = 'lentils, spicy'
+      bookmark.save
+      expect(bookmark.reload.tags.collect(&:name)).to include('lentils')
+    end
+
+    it 'removes old tags' do
+      bookmark.tag_list = 'lentils, spicy'
+      bookmark.save
+      bookmark.reload.tag_list = 'spicy'
+      bookmark.save
+      expect(bookmark.reload.tags.collect(&:name)).not_to include('lentils')
+    end
+  end
 end

--- a/spec/models/tagging_spec.rb
+++ b/spec/models/tagging_spec.rb
@@ -1,0 +1,14 @@
+require 'rails_helper'
+
+RSpec.describe Tagging, type: :model do
+  let(:bookmark) { build(:bookmark) }
+
+  describe 'after_destroy' do
+    it 'removes unused tags' do
+      bookmark.tag_list = 'spicy, lentils, potatoes'
+      bookmark.save
+      bookmark.reload
+      expect { bookmark.destroy }.to change(Tag, :count).by(-3)
+    end
+  end
+end


### PR DESCRIPTION
This update adds very basic tagging, such that you can create a comma-separated list of tags for a model, and associated tags and taggings will be created after save.