### PR TITLE
Add basic searching for bookmarks

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -18,6 +18,7 @@ Metrics/BlockLength:
     - 'spec/helpers/**/*'
     - 'spec/models/**/*'
     - 'spec/policies/**/*'
+    - 'spec/requests/**/*'
     - 'spec/routing/**/*'
 
 Metrics/ModuleLength:
@@ -58,6 +59,7 @@ RSpec/ExampleLength:
   Exclude:
     - 'spec/controllers/**/*'
     - 'spec/helpers/**/*'
+    - 'spec/requests/**/*'
     - 'spec/views/**/*'
 
 RSpec/ExpectActual:

--- a/app/controllers/bookmarks_controller.rb
+++ b/app/controllers/bookmarks_controller.rb
@@ -77,6 +77,14 @@ class BookmarksController < ApplicationController
     end
   end
 
+  def search
+    @bookmarks = Bookmark.includes(:tags)
+                         .where(tags: {
+                                  name: params[:q].split(','),
+                                })
+    render :index
+  end
+
   private
 
   def set_bookmark

--- a/app/views/bookmarks/index.html.slim
+++ b/app/views/bookmarks/index.html.slim
@@ -1,21 +1,32 @@
 .container.pb-2.grid-sm
-  - @bookmarks.each do |bookmark|
-    .columns.pb-3
-      .column.col-8
-        .bookmark__title.d-block.mb-1
-          = link_to bookmark.url, target: '_blank', class: 'd-inline-block' do
-            = fa_icon 'external-link', class: 'mr-1'
-            - if bookmark.title?
-              = link_to bookmark.title, bookmark.url, target: '_blank'
-            - else
-              = link_to 'Visit', bookmark.url, target: '_blank'
-        .bookmark__tags.d-block.mb-1
-          - bookmark.tags.each do |tag|
-            span.chip = tag.name
-        small.bookmark__url.d-block.text-ellipsis.text-gray
-            = bookmark.url
-      .column.col-4.text-right
-        .btn-group
-          = link_to 'Show', bookmark, class: 'btn btn-outline'
-          = link_to 'Edit', edit_bookmark_path(bookmark), class: 'btn btn-outline'
-          = link_to 'Destroy', bookmark, class: 'btn btn-outline', data: { confirm: 'Are you sure?' }, method: :delete
+  - if @bookmarks.any?
+    - @bookmarks.each do |bookmark|
+      .columns.pb-3
+        .column.col-8
+          .bookmark
+            .bookmark__title.d-block.mb-1
+              = link_to bookmark.url, target: '_blank', class: 'd-inline-block' do
+                = fa_icon 'external-link', class: 'mr-1'
+                - if bookmark.title?
+                  = link_to bookmark.title, bookmark.url, target: '_blank'
+                - else
+                  = link_to 'Visit', bookmark.url, target: '_blank'
+            .bookmark__tags.d-block.mb-1
+              - bookmark.tags.each do |tag|
+                span.chip = tag.name
+            small.bookmark__url.d-block.text-ellipsis.text-gray
+                = bookmark.url
+        .column.col-4.text-right
+          .btn-group
+            = link_to 'Show', bookmark, class: 'btn btn-outline'
+            = link_to 'Edit', edit_bookmark_path(bookmark), class: 'btn btn-outline'
+            = link_to 'Destroy', bookmark, class: 'btn btn-outline', data: { confirm: 'Are you sure?' }, method: :delete
+  - else
+    .empty
+      .empty-icon
+        i.icon.icon-people
+      p.empty-title.h5 No bookmarks found
+      p.empty-subtitle Would you like to add one?
+      .empty-action
+        = link_to new_bookmark_path, class: 'btn btn-primary' do
+          | Add a bookmark

--- a/app/views/bookmarks/show.html.slim
+++ b/app/views/bookmarks/show.html.slim
@@ -16,7 +16,7 @@
 
       - if @bookmark.notes?
         p
-          = markdown(@bookmark.notes).html_safe
+          = sanitize(markdown(@bookmark.notes).html_safe)
 
     .column.col-12.pt-2
       .btn-group.mr-2

--- a/app/views/layouts/application.html.slim
+++ b/app/views/layouts/application.html.slim
@@ -14,11 +14,13 @@ html lang="en"
               a.navbar-brand.mr-2 href="/bookmarks" Bookmarks
               a.btn.btn-link target="_blank" href="https://github.com/christopherstyles/bookmark-manager" GitHub
             section.navbar-section
-              .input-group.input-inline
-                input.form-input placeholder="search" type="text" /
-                button.btn.btn-primary.input-group-btn Search
+              = form_tag search_bookmarks_path, method: :get do
+                .input-group.input-inline
+                  input.form-input#search_input placeholder="search" type="text" name="q" /
+                  button.btn.btn-primary.input-group-btn Search
     .divider.mb-0
     = link_to new_bookmark_path, class: 'btn btn-primary btn-lg btn-block mb-4' do
       = fa_icon 'plus-circle', class: 'mr-1'
       | New Bookmark
+
     = yield

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,5 +1,7 @@
 Rails.application.routes.draw do
-  resources :bookmarks
-  
+  resources :bookmarks do
+    get :search, on: :collection
+  end
+
   root to: 'bookmarks#index'
 end

--- a/spec/factories/taggings.rb
+++ b/spec/factories/taggings.rb
@@ -1,6 +1,6 @@
 FactoryGirl.define do
   factory :tagging do
-    taggable_type { Faker::Lorem.word }
-    taggable_id { SecureRandom.uuid }
+    association :taggable, factory: :bookmark
+    tag
   end
 end

--- a/spec/factories/tags.rb
+++ b/spec/factories/tags.rb
@@ -1,6 +1,5 @@
 FactoryGirl.define do
   factory :tag do
     name { Faker::Lorem.word }
-    type { Faker::Lorem.word }
   end
 end

--- a/spec/requests/bookmarks_spec.rb
+++ b/spec/requests/bookmarks_spec.rb
@@ -2,9 +2,45 @@ require 'rails_helper'
 
 RSpec.describe 'Bookmarks', type: :request do
   describe 'GET /bookmarks' do
-    it 'works! (now write some real specs)' do
+    it 'displays bookmarks' do
+      bookmark1 = create(:bookmark)
+      bookmark2 = create(:bookmark)
+
       get bookmarks_path
+
       expect(response).to have_http_status(200)
+
+      assert_select '.bookmark' do
+        assert_select '.bookmark__url', bookmark1.url
+        assert_select '.bookmark__url', bookmark2.url
+      end
+    end
+
+    it 'displays search results' do
+      tag1 = create(:tag, name: 'rubyonrails')
+      tag2 = create(:tag, name: 'composition')
+
+      bookmark1 = create(:bookmark)
+      bookmark2 = create(:bookmark)
+
+      create(
+        :tagging, taggable: bookmark1,
+                  tag: tag1
+      )
+
+      create(
+        :tagging, taggable: bookmark2,
+                  tag: tag2
+      )
+
+      get search_bookmarks_path(q: 'rubyonrails,composition')
+
+      expect(response).to have_http_status(200)
+
+      assert_select '.bookmark' do
+        assert_select '.bookmark__url', bookmark1.url
+        assert_select '.bookmark__url', bookmark2.url
+      end
     end
   end
 end

--- a/spec/routing/bookmarks_routing_spec.rb
+++ b/spec/routing/bookmarks_routing_spec.rb
@@ -33,5 +33,10 @@ RSpec.describe BookmarksController, type: :routing do
     it 'routes to #destroy' do
       expect(delete: '/bookmarks/1').to route_to('bookmarks#destroy', id: '1')
     end
+
+    it 'routes to #search' do
+      expect(get: '/bookmarks/search?q=rails,composition')
+        .to route_to('bookmarks#search', q: 'rails,composition')
+    end
   end
 end


### PR DESCRIPTION
This update adds _very_ basic searching for bookmarks. Input in the top searchbar is expected to be a comma-separated list, and results are displayed in the search action with an `index` rendered view.