### PR TITLE
Rename factory_girl to factory_bot

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -34,7 +34,7 @@ end
 group :development, :test do
   gem 'byebug', platforms: %i(mri mingw x64_mingw)
   gem 'capybara', '~> 2.13'
-  gem 'factory_girl_rails', '~> 4.0'
+  gem 'factory_bot_rails'
   gem 'faker', '~> 1.8.4'
   gem 'rspec-rails', '~> 3.6'
   gem 'selenium-webdriver'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -73,10 +73,10 @@ GEM
     erubi (1.6.1)
     eventmachine (1.2.5)
     execjs (2.7.0)
-    factory_girl (4.8.0)
+    factory_bot (4.8.2)
       activesupport (>= 3.0.0)
-    factory_girl_rails (4.8.0)
-      factory_girl (~> 4.8.0)
+    factory_bot_rails (4.8.2)
+      factory_bot (~> 4.8.2)
       railties (>= 3.0.0)
     faker (1.8.4)
       i18n (~> 0.5)
@@ -299,7 +299,7 @@ PLATFORMS
 DEPENDENCIES
   byebug
   capybara (~> 2.13)
-  factory_girl_rails (~> 4.0)
+  factory_bot_rails
   faker (~> 1.8.4)
   font-awesome-rails
   guard
@@ -335,4 +335,4 @@ DEPENDENCIES
   web-console (>= 3.3.0)
 
 BUNDLED WITH
-   1.16.0.pre.2
+   1.16.0

--- a/spec/factories/bookmarks.rb
+++ b/spec/factories/bookmarks.rb
@@ -1,4 +1,4 @@
-FactoryGirl.define do
+FactoryBot.define do
   factory :bookmark do
     url { Faker::Internet.url }
 

--- a/spec/factories/taggings.rb
+++ b/spec/factories/taggings.rb
@@ -1,4 +1,4 @@
-FactoryGirl.define do
+FactoryBot.define do
   factory :tagging do
     association :taggable, factory: :bookmark
     tag

--- a/spec/factories/tags.rb
+++ b/spec/factories/tags.rb
@@ -1,4 +1,4 @@
-FactoryGirl.define do
+FactoryBot.define do
   factory :tag do
     name { Faker::Lorem.word }
   end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -11,7 +11,7 @@ end
 require 'rspec/rails'
 # Add additional requires below this line. Rails is not loaded until this point!
 
-require 'support/factory_girl'
+require 'support/factory_bot'
 require 'support/shoulda_matchers'
 
 # Requires supporting ruby files with custom matchers and macros, etc, in

--- a/spec/support/factory_bot.rb
+++ b/spec/support/factory_bot.rb
@@ -1,0 +1,3 @@
+RSpec.configure do |config|
+  config.include FactoryBot::Syntax::Methods
+end

--- a/spec/support/factory_girl.rb
+++ b/spec/support/factory_girl.rb
@@ -1,3 +1,0 @@
-RSpec.configure do |config|
-  config.include FactoryGirl::Syntax::Methods
-end


### PR DESCRIPTION
This update renames the factory_girl gem to [factory_bot](https://github.com/thoughtbot/factory_bot_rails). Upgrade path is available [here](https://github.com/thoughtbot/factory_bot/blob/4-9-0-stable/UPGRADE_FROM_FACTORY_GIRL.md), but this was an easy change. And long time coming, good job [thoughtbot](https://github.com/thoughtbot)!